### PR TITLE
#11 Fixed: The lookup type in the mock is now the same as the input v…

### DIFF
--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/brreg/BrregDevConfig.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/brreg/BrregDevConfig.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class BrregDevConfig {
     @Bean
     BrregClient brregClient() {
-        Map<Optional<String>, Optional<BrregEnhet>> brregMock = new TestEnvironmentEnheter().getTestMiljøEnheter();
+        Map<String, Optional<BrregEnhet>> brregMock = new TestEnvironmentEnheter().getTestMiljøEnheter();
 
         return orgnr -> brregMock.getOrDefault(orgnr, Optional.empty());
     }

--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/brreg/dev/TestEnvironmentEnheter.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/service/brreg/dev/TestEnvironmentEnheter.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import no.difi.meldingsutveksling.serviceregistry.model.BrregEnhet;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 
 public class TestEnvironmentEnheter {
@@ -31,9 +32,9 @@ public class TestEnvironmentEnheter {
         return biristrand;
     }
 
-    public ImmutableMap<Optional<String>, Optional<BrregEnhet>> getTestMiljøEnheter() {
-        ImmutableMap.Builder<Optional<String>, Optional<BrregEnhet>> builder = ImmutableMap.builder();
-        Arrays.stream(enheter).forEach(e -> builder.put(e.getOrganisasjonsnummer(), Optional.of(e)));
+    public Map<String, Optional<BrregEnhet>> getTestMiljøEnheter() {
+        ImmutableMap.Builder<String, Optional<BrregEnhet>> builder = ImmutableMap.builder();
+        Arrays.stream(enheter).forEach(e -> builder.put(e.getOrganisasjonsnummer().get(), Optional.of(e)));
         return builder.build();
     }
 }

--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/servicerecord/ServiceRecord.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/servicerecord/ServiceRecord.java
@@ -9,7 +9,6 @@ import no.difi.virksert.client.VirksertClientException;
 import org.springframework.core.env.Environment;
 
 import java.io.Serializable;
-import java.net.URL;
 import java.security.cert.Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,7 +47,7 @@ public abstract class ServiceRecord implements Serializable {
         this.serviceIdentifier = serviceIdentifier;
     }
 
-    public String getX509Certificate() {
+    public String getPemCertificate() {
         try {
             Certificate c = virkSertService.getCertificate(getOrganisationNumber());
             return CertificateToString.toString(c);
@@ -62,7 +61,7 @@ public abstract class ServiceRecord implements Serializable {
         return "ServiceRecord{" +
                 "serviceIdentifier='" + serviceIdentifier + '\'' +
                 ", organisationNumber='" + organisationNumber + '\'' +
-                ", x509Certificate='" + getX509Certificate() + '\'' +
+                ", pemCertificate='" + getPemCertificate() + '\'' +
                 ", endPointURL='" + getEndPointURL().toString() + '\'' +
                 '}';
     }

--- a/serviceregistry-server/src/main/resources/application.properties
+++ b/serviceregistry-server/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 logging.level.org.springframework.web=DEBUG
+server.port=9099


### PR DESCRIPTION
…alue. This resulted in not finding the correct value.

Minor fixes:
Changed default port of application from 8080 to 9099
Removed systest using brreg mock client
Renamed certificate in return value of ServiceRecord to pemCertificate (make certificate format/encoding obvious to the user of the service).