### PR TITLE
closes #19 Lookup of organizations of type AS no longer results in NPE.

### DIFF
--- a/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/controller/OrganizationController.java
+++ b/serviceregistry-server/src/main/java/no/difi/meldingsutveksling/serviceregistry/controller/OrganizationController.java
@@ -36,9 +36,6 @@ public class OrganizationController {
     private BrregService brregService;
     private PrimaryServiceStore store;
 
-    @Autowired
-    private Environment environment;
-
     /**
      *
      * @param virkSertService used to retrieve organization certificates
@@ -48,7 +45,7 @@ public class OrganizationController {
      * @param brregService needed to lookup and retrieve organization information using an organization number
      */
     @Autowired
-    public OrganizationController(VirkSertService virkSertService, ELMALookupService elmaLookupSerice, KSLookup ksLookup, PrimaryServiceStore store, BrregService brregService) {
+    public OrganizationController(VirkSertService virkSertService, ELMALookupService elmaLookupSerice, KSLookup ksLookup, PrimaryServiceStore store, BrregService brregService, Environment environment) {
         this.brregService = brregService;
         this.store = store;
         this.serviceRecordFactory = new ServiceRecordFactory(environment, virkSertService, elmaLookupSerice, ksLookup);


### PR DESCRIPTION
Spring wiring was wrong: undeterministic autowiring of Environment into OrganizationController. Resulted in NPE where accessing Environment.